### PR TITLE
Reset prediction execution state on reset

### DIFF
--- a/crates/nevy_prediction/src/client/prediction.rs
+++ b/crates/nevy_prediction/src/client/prediction.rs
@@ -156,7 +156,7 @@ fn run_prediction_world(world: &mut World) {
                     >= desired_tick
                 {
                     if current_tick > desired_tick {
-                        warn!(
+                        error!(
                             "Predicted more ticks than desired. Predicted to {:?} instead of {:?}",
                             current_tick, desired_tick,
                         );

--- a/crates/nevy_prediction/src/client/prediction.rs
+++ b/crates/nevy_prediction/src/client/prediction.rs
@@ -89,6 +89,14 @@ impl PredictionWorld {
             state: PredictionWorldState::Idle,
         }
     }
+
+    pub fn reset<S>(&mut self, tick: SimulationTick)
+    where
+        S: PredictionScheme,
+    {
+        self.world.reset::<S>(tick);
+        self.state = PredictionWorldState::Idle;
+    }
 }
 
 fn run_prediction_world(world: &mut World) {


### PR DESCRIPTION
When reseting the simulation we were previously not setting the execution state of the prediction app, causing it to get confused when the prediction world was modified out from under it. Fixed that.