### PR TITLE
Make template world public.

### DIFF
--- a/crates/nevy_prediction/src/client/simulation_world.rs
+++ b/crates/nevy_prediction/src/client/simulation_world.rs
@@ -11,8 +11,8 @@ use crate::common::{
 };
 
 /// A separate world for containing prediction logic
-#[derive(Resource, Deref, DerefMut)]
-pub(crate) struct SimulationWorld(World);
+#[derive(Deref, DerefMut)]
+pub struct SimulationWorld(World);
 
 impl SimulationWorld {
     pub fn build(mut app: App) -> Self {

--- a/crates/nevy_prediction/src/client/template_world.rs
+++ b/crates/nevy_prediction/src/client/template_world.rs
@@ -55,8 +55,14 @@ where
 }
 
 /// Contains a [`SimulationWorld`] that holds the most recently known state of the simulation according to the server.
+/// This is the "source of truth" for the simulation on the client.
+///
+/// Unlike the prediction world, this world is public. This allows for mutating the simulation outside of the normal world update flow.
+/// This is meant to be used for loading data slowly where the tradeoff of a moment of desync is more desireable than a large hitch.
+///
+/// Derefs directly to a [`World`].
 #[derive(Resource, Deref, DerefMut)]
-pub(crate) struct TemplateWorld(pub SimulationWorld);
+pub struct TemplateWorld(pub SimulationWorld);
 
 impl TemplateWorld {
     pub fn build<S>() -> Self

--- a/crates/nevy_prediction/src/lib.rs
+++ b/crates/nevy_prediction/src/lib.rs
@@ -5,7 +5,7 @@ pub mod server;
 pub mod prelude {
     pub use crate::client::{
         ClientSimulationSystems, NevyPredictionClientPlugin, PredictionInterval, PredictionRates,
-        PredictionServerConnection, PredictionUpdateCreator,
+        PredictionServerConnection, PredictionUpdateCreator, template_world::TemplateWorld,
     };
 
     pub use crate::common::{


### PR DESCRIPTION
made template world public, added docs explaining why and added it to the prelude.

"Unlike the prediction world, this world is public. This allows for mutating the simulation outside of the normal world update flow.
This is meant to be used for loading data slowly where the tradeoff of a moment of desync is more desireable than a large hitch."

Motivated by a use case where we want to load voxel colliders in the main world, and then once they've loaded clone them into the template world.