### PR TITLE
try_despawn simulation entities to avoid warnings.

### DIFF
--- a/crates/nevy_prediction/src/common/simulation/mod.rs
+++ b/crates/nevy_prediction/src/common/simulation/mod.rs
@@ -36,7 +36,7 @@ pub mod update_component;
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ExtractSimulationSystems {
     /// Where new simulation entities are extracted.
-    ExtractEntities,
+    ExtractSimulationEntities,
     /// Where components added by
     /// [`ExtractSimulationComponentPlugin`](extract_component::ExtractSimulationComponentPlugin)
     /// and relations added by [`ExtractSimulationRelationPlugin`](extract_relation::ExtractSimulationRelationPlugin)
@@ -124,7 +124,7 @@ where
         app.configure_sets(
             ExtractSimulation,
             (
-                ExtractSimulationSystems::ExtractEntities,
+                ExtractSimulationSystems::ExtractSimulationEntities,
                 ExtractSimulationSystems::ExtractComponents,
                 ExtractSimulationSystems::DespawnSimulationEntities,
             )

--- a/crates/nevy_prediction/src/common/simulation/schedules.rs
+++ b/crates/nevy_prediction/src/common/simulation/schedules.rs
@@ -34,7 +34,7 @@ pub struct SimulationPostUpdate;
 #[derive(ScheduleLabel, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct ResetSimulation;
 
-/// Schedule that extracts the simulation state from a [`SourceWorld`] into the current (local) world.
+/// Schedule that extracts the simulation state from a [`SourceWorld`](crate::common::simulation::SourceWorld) into the current (local) world.
 #[derive(ScheduleLabel, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ExtractSimulation;
 


### PR DESCRIPTION
In the extract schedule there is a system that despawns all simulation entities that aren't in the source world.

If there are simulation entities in a hierachy and both need to be despawned, despawning the parent first can the child to be despawned twice causing a warning.

This is fine, as the result is both being despawned either way, so we use `try_despawn` instead to omit the warning.