### PR TITLE
added extract despawn ordering

### DIFF
--- a/crates/nevy_prediction/src/lib.rs
+++ b/crates/nevy_prediction/src/lib.rs
@@ -23,8 +23,8 @@ pub mod prelude {
                 SimulationUpdate,
             },
             simulation_entity::{
-                DespawnSimulationEntities, DespawnSimulatonEntity, SimulationEntity,
-                SimulationEntityMap,
+                DespawnSimulationEntities, DespawnSimulatonEntity, ExtractDespawnPriority,
+                SimulationEntity, SimulationEntityMap,
             },
             update_component::{UpdateComponent, UpdateComponentPlugin, UpdateComponentSystems},
         },


### PR DESCRIPTION
Added a new component `ExtractDespawnOrdering(i32)`. When the default logic for despawning `SimulationEntity`s runs it will despawn entities with a lower priority first.